### PR TITLE
Bump System.Data.SqlClient from 4.8.3 to 4.8.5 in /LokiBulkDataProces…

### DIFF
--- a/LokiBulkDataProcessor/LokiBulkDataProcessor.csproj
+++ b/LokiBulkDataProcessor/LokiBulkDataProcessor.csproj
@@ -24,7 +24,7 @@
   <ItemGroup>
     <PackageReference Include="FastMember" Version="1.5.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.3" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\LICENSE.txt">


### PR DESCRIPTION
…sor (#4)

Bumps [System.Data.SqlClient](https://github.com/dotnet/corefx) from 4.8.3 to 4.8.5.
- [Release notes](https://github.com/dotnet/corefx/releases)
- [Commits](https://github.com/dotnet/corefx/commits)

---
updated-dependencies:
- dependency-name: System.Data.SqlClient dependency-type: direct:production ...